### PR TITLE
chore: adduser

### DIFF
--- a/.github/workflows/sysdig-teams.yml
+++ b/.github/workflows/sysdig-teams.yml
@@ -22,7 +22,9 @@ jobs:
           - host: https://api.gold.devops.gov.bc.ca:6443
             plate: eb75ad
             token: GOLD_EB75AD_OPENSHIFT_TOKEN
-
+          - host: https://api.silver.devops.gov.bc.ca:6443
+            plate: 3d5c3f
+            token: SILVER_3D5C3F_OPENSHIFT_TOKEN
     steps:
       - uses: hmarr/debug-action@v2
       - uses: actions/checkout@v2

--- a/sysdig-teams-non-helm/README.md
+++ b/sysdig-teams-non-helm/README.md
@@ -1,0 +1,1 @@
+Regenrate a sysdig team using helm forces us to delete the previous configuration. (alerts, dashboards, notification channels, etc)  Rather than risk that, we will save the `team.yaml` for production silver environment and manually run it when we need to update the sysdig access for our team.

--- a/sysdig-teams-non-helm/team.yaml
+++ b/sysdig-teams-non-helm/team.yaml
@@ -1,0 +1,23 @@
+apiVersion: ops.gov.bc.ca/v1alpha1
+kind: SysdigTeam
+metadata:
+  name: 6d70e7-team
+  namespace: 6d70e7-tools
+spec:
+  team:
+    description: The Sysdig Team for the SSO Prod Namespaces
+    users:
+    - name: zorin.samji@gov.bc.ca
+      role: ROLE_TEAM_MANAGER
+    - name: arcshiftsolutions@gmail.com
+      role: ROLE_TEAM_MANAGER
+    - name: junmin@button.is
+      role: ROLE_TEAM_MANAGER
+    - name: jonathan.sharman@gov.bc.ca
+      role: ROLE_TEAM_MANAGER
+    - name: tzhang200@gmail.com
+      role: ROLE_TEAM_MANAGER
+    - name: nithinshekar.kuruba@gmail.com
+      role: ROLE_TEAM_MANAGER
+    - name: c.gustafson@cgi.com
+      role: ROLE_TEAM_MANAGER

--- a/sysdig-teams/deploy-3d5c3f.sh
+++ b/sysdig-teams/deploy-3d5c3f.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+helm repo add sso-charts https://bcgov.github.io/sso-helm-charts
+helm repo update
+
+helm upgrade --install sysdig-teams sso-charts/sysdig -n 3d5c3f-tools -f values-3d5c3f.yaml

--- a/sysdig-teams/values-3d5c3f.yaml
+++ b/sysdig-teams/values-3d5c3f.yaml
@@ -1,0 +1,16 @@
+licensePlate: 3d5c3f
+users:
+  - name: zorin.samji@gov.bc.ca
+    role: ROLE_TEAM_MANAGER
+  - name: arcshiftsolutions@gmail.com
+    role: ROLE_TEAM_MANAGER
+  - name: junmin@button.is
+    role: ROLE_TEAM_MANAGER
+  - name: jonathan.sharman@gov.bc.ca
+    role: ROLE_TEAM_MANAGER
+  - name: tzhang200@gmail.com
+    role: ROLE_TEAM_MANAGER
+  - name: nithinshekar.kuruba@gmail.com
+    role: ROLE_TEAM_MANAGER
+  - name: c.gustafson@cgi.com
+    role: ROLE_TEAM_MANAGER


### PR DESCRIPTION
add the silver sandbox to sysdig
The alerts and dashboards for sandbox have been backed up locally just in case.
builder secret has been added 