### PR TITLE
chore: add a dev and test pvc alert to silver

### DIFF
--- a/terraform/gold-eb75ad-team/alerts.tf
+++ b/terraform/gold-eb75ad-team/alerts.tf
@@ -259,7 +259,7 @@ resource "sysdig_monitor_alert_promql" "prod_db_pv_usage_med" {
 
 resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_seventyfive" {
   name        = "[GOLD CUST DEV] SSO DB PV over 75%"
-  description = "only alert rocket chat and emainl for 75%"
+  description = "only alert rocket chat and email for 75%"
   severity    = 4
   enabled     = true
 
@@ -289,7 +289,7 @@ resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_ninety" {
 
 resource "sysdig_monitor_alert_promql" "test_db_pv_usage_seventyfive" {
   name        = "[GOLD CUST TEST] SSO DB PV over 75%"
-  description = "only alert rocket chat and emainl for 75%"
+  description = "only alert rocket chat and email for 75%"
   severity    = 4
   enabled     = true
 

--- a/terraform/gold-eb75ad-team/alerts.tf
+++ b/terraform/gold-eb75ad-team/alerts.tf
@@ -258,7 +258,7 @@ resource "sysdig_monitor_alert_promql" "prod_db_pv_usage_med" {
 }
 
 resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_seventyfive" {
-  name        = "[GOLD CUST DEV] SSO DB PV over 80%"
+  name        = "[GOLD CUST DEV] SSO DB PV over 75%"
   description = "only alert rocket chat and emainl for 75%"
   severity    = 4
   enabled     = true
@@ -273,7 +273,7 @@ resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_seventyfive" {
 }
 
 resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_ninety" {
-  name        = "[GOLD CUST DEV] SSO DB PV over 80%"
+  name        = "[GOLD CUST DEV] SSO DB PV over 90%"
   description = ""
   severity    = 4
   enabled     = true
@@ -288,7 +288,7 @@ resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_ninety" {
 }
 
 resource "sysdig_monitor_alert_promql" "test_db_pv_usage_seventyfive" {
-  name        = "[GOLD CUST TEST] SSO DB PV over 80%"
+  name        = "[GOLD CUST TEST] SSO DB PV over 75%"
   description = "only alert rocket chat and emainl for 75%"
   severity    = 4
   enabled     = true
@@ -303,7 +303,7 @@ resource "sysdig_monitor_alert_promql" "test_db_pv_usage_seventyfive" {
 }
 
 resource "sysdig_monitor_alert_promql" "test_db_pv_usage_ninety" {
-  name        = "[GOLD CUST TEST] SSO DB PV over 80%"
+  name        = "[GOLD CUST TEST] SSO DB PV over 90%"
   description = ""
   severity    = 4
   enabled     = true

--- a/terraform/gold-eb75ad-team/alerts.tf
+++ b/terraform/gold-eb75ad-team/alerts.tf
@@ -256,3 +256,63 @@ resource "sysdig_monitor_alert_promql" "prod_db_pv_usage_med" {
     title = "{{__alert_name__}} is {{__alert_status__}}"
   }
 }
+
+resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_seventyfive" {
+  name        = "[GOLD CUST DEV] SSO DB PV over 80%"
+  description = "only alert rocket chat and emainl for 75%"
+  severity    = 4
+  enabled     = true
+
+  promql                = "avg(kubelet_volume_stats_used_bytes{namespace=\"eb75ad-dev\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}*100 / kubelet_volume_stats_capacity_bytes{namespace=\"eb75ad-dev\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}) by (persistentvolumeclaim) > 75"
+  trigger_after_minutes = 2
+
+  notification_channels = [45990, 57336]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "dev_db_pv_usage_ninety" {
+  name        = "[GOLD CUST DEV] SSO DB PV over 80%"
+  description = ""
+  severity    = 4
+  enabled     = true
+
+  promql                = "avg(kubelet_volume_stats_used_bytes{namespace=\"eb75ad-dev\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}*100 / kubelet_volume_stats_capacity_bytes{namespace=\"eb75ad-dev\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}) by (persistentvolumeclaim) > 90"
+  trigger_after_minutes = 2
+
+  notification_channels = [45990, 57336, 57341]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "test_db_pv_usage_seventyfive" {
+  name        = "[GOLD CUST TEST] SSO DB PV over 80%"
+  description = "only alert rocket chat and emainl for 75%"
+  severity    = 4
+  enabled     = true
+
+  promql                = "avg(kubelet_volume_stats_used_bytes{namespace=\"eb75ad-test\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}*100 / kubelet_volume_stats_capacity_bytes{namespace=\"eb75ad-test\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}) by (persistentvolumeclaim) > 75"
+  trigger_after_minutes = 2
+
+  notification_channels = [45990, 57336]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "test_db_pv_usage_ninety" {
+  name        = "[GOLD CUST TEST] SSO DB PV over 80%"
+  description = ""
+  severity    = 4
+  enabled     = true
+
+  promql                = "avg(kubelet_volume_stats_used_bytes{namespace=\"eb75ad-test\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}*100 / kubelet_volume_stats_capacity_bytes{namespace=\"eb75ad-test\", persistentvolumeclaim=~\"storage-volume-sso-patroni-.*\"}) by (persistentvolumeclaim) > 90"
+  trigger_after_minutes = 2
+
+  notification_channels = [45990, 57336, 57341]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}

--- a/terraform/silver-6d70e7-team/alerts-promql.tf
+++ b/terraform/silver-6d70e7-team/alerts-promql.tf
@@ -150,6 +150,86 @@ resource "sysdig_monitor_alert_promql" "patroni_pvc_over_sixty" {
   }
 }
 
+resource "sysdig_monitor_alert_promql" "patroni_dev_pvc_over_ninety" {
+  name                  = "Patroni - Dev PVCs > 90% Terraform Silver"
+  description           = "Managed by terraform: To resolve, redeploy the patroni helm chart 'silver-patroni' in the sso-keycloak repo with an updated values file."
+  severity              = 4
+  enabled               = true
+  promql                = <<-EOT
+          avg(
+            kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-dev-11-patroni-.*"}*100
+            /
+            kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-dev-11-patroni-.*"}
+          ) by (persistentvolumeclaim)
+          > 90
+          EOT
+  trigger_after_minutes = 10
+  notification_channels = [45990, 47291, 47595]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "patroni_dev_pvc_over_seventyfive" {
+  name                  = "Patroni - Dev PVCs > 75% Terraform Silver"
+  description           = "Managed by terraform: Only alert rocket chat and email for 75%."
+  severity              = 4
+  enabled               = true
+  promql                = <<-EOT
+          avg(
+            kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-dev-11-patroni-.*"}*100
+            /
+            kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-dev-11-patroni-.*"}
+          ) by (persistentvolumeclaim)
+          > 75
+          EOT
+  trigger_after_minutes = 10
+  notification_channels = [45990, 47291]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "patroni_test_pvc_over_ninety" {
+  name                  = "Patroni - Test PVCs > 90% Terraform Silver"
+  description           = "Managed by terraform: To resolve, redeploy the patroni helm chart 'silver-patroni' in the sso-keycloak repo with an updated values file."
+  severity              = 4
+  enabled               = true
+  promql                = <<-EOT
+          avg(
+            kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-test-11-patroni-.*"}*100
+            /
+            kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-test-11-patroni-.*"}
+          ) by (persistentvolumeclaim)
+          > 90
+          EOT
+  trigger_after_minutes = 10
+  notification_channels = [45990, 47291, 47595]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+resource "sysdig_monitor_alert_promql" "patroni_test_pvc_over_seventyfive" {
+  name                  = "Patroni - Test PVCs > 75% Terraform Silver"
+  description           = "Managed by terraform: Only alert rocket chat and email for 75%."
+  severity              = 4
+  enabled               = true
+  promql                = <<-EOT
+          avg(
+            kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-test-11-patroni-.*"}*100
+            /
+            kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"storage-volume-sso-pgsql-test-11-patroni-.*"}
+          ) by (persistentvolumeclaim)
+          > 75
+          EOT
+  trigger_after_minutes = 10
+  notification_channels = [45990, 47291]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
 resource "sysdig_monitor_alert_promql" "patroni_backup_pvc_over_sixty" {
   name                  = "Patroni - Backup PVC over 60% Terraform Silver"
   description           = "Managed by terraform: To resolve, redeploy the backup strorage helm chart in the sso-keycloak repo with an updated values file."


### PR DESCRIPTION
This alert only triggers to rocket chat and email for 75% pvc in dev or test silver.  When the PVC hits 90 % it alerts opsgenie