### PR TITLE
feat: create a sysdig alert for a sustained high CPU

### DIFF
--- a/terraform/gold-eb75ad-team/alerts.tf
+++ b/terraform/gold-eb75ad-team/alerts.tf
@@ -47,7 +47,7 @@ resource "sysdig_monitor_alert_metric" "prod_keycloak_cpu_usage_med" {
   scope              = "kubernetes.cluster.name in (\"gold\") and kubernetes.namespace.name in (\"eb75ad-prod\") and kubernetes.deployment.name in (\"sso-keycloak\")"
   multiple_alerts_by = []
 
-  notification_channels = [132277, 57336]
+  notification_channels = [132277, 57336, 57341]
   custom_notification {
     title = "{{__alert_name__}} is {{__alert_status__}}"
   }
@@ -66,7 +66,7 @@ resource "sysdig_monitor_alert_metric" "prod_keycloak_cpu_usage_sustained" {
   scope              = "kubernetes.cluster.name in (\"gold\") and kubernetes.namespace.name in (\"eb75ad-prod\") and kubernetes.deployment.name in (\"sso-keycloak\")"
   multiple_alerts_by = []
 
-  notification_channels = [132277, 57336, 57341]
+  notification_channels = [132277, 57336]
   custom_notification {
     title = "{{__alert_name__}} is {{__alert_status__}}"
   }

--- a/terraform/gold-eb75ad-team/alerts.tf
+++ b/terraform/gold-eb75ad-team/alerts.tf
@@ -47,6 +47,25 @@ resource "sysdig_monitor_alert_metric" "prod_keycloak_cpu_usage_med" {
   scope              = "kubernetes.cluster.name in (\"gold\") and kubernetes.namespace.name in (\"eb75ad-prod\") and kubernetes.deployment.name in (\"sso-keycloak\")"
   multiple_alerts_by = []
 
+  notification_channels = [132277, 57336]
+  custom_notification {
+    title = "{{__alert_name__}} is {{__alert_status__}}"
+  }
+}
+
+
+resource "sysdig_monitor_alert_metric" "prod_keycloak_cpu_usage_sustained" {
+  name        = "[GOLD CUST PROD] Keycloak - Sustained Elevated CPU"
+  description = "When the CPU is elevated for a long period of time it may indicate pod health issues."
+  severity    = 4
+  enabled     = true
+
+  metric                = "max(avg(sysdig_container_cpu_cores_used)) >= 0.15"
+  trigger_after_minutes = 30
+
+  scope              = "kubernetes.cluster.name in (\"gold\") and kubernetes.namespace.name in (\"eb75ad-prod\") and kubernetes.deployment.name in (\"sso-keycloak\")"
+  multiple_alerts_by = []
+
   notification_channels = [132277, 57336, 57341]
   custom_notification {
     title = "{{__alert_name__}} is {{__alert_status__}}"


### PR DESCRIPTION
This may need to be fine tuned in the future (duration of interval, and alert threshold) but it should alert Rocket chat and emails to sustained spikes like those that lead up to the previous outages.)